### PR TITLE
Logging Change Proposal, Bug Fix for VxAnalyzer, and Fail Faster in Netpool Analysis

### DIFF
--- a/firmware_tools/ghidra/vxhunter_analysis.py
+++ b/firmware_tools/ghidra/vxhunter_analysis.py
@@ -1,29 +1,32 @@
+import logging
+import json
+
 from vxhunter_core import *
 from vxhunter_utility.function_analyzer import *
 from vxhunter_utility.symbol import *
 from vxhunter_utility.common import create_initialized_block
 from ghidra.program.model.symbol import RefType, SourceType
-import json
 
+
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
+logger.setLevel(logging.INFO)
+consolehandler = logging.StreamHandler()
+console_format = logging.Formatter('[%(levelname)-8s][%(module)s.%(funcName)s] %(message)s')
+consolehandler.setFormatter(console_format)
+logger.addHandler(consolehandler)
 
 class VxAnalyzer(object):
-    def __init__(self, logger=None):
+    def __init__(self):
         self._vx_version = None
         self.report = []
 
-        if logger is None:
-            self.logger = logging.getLogger('target')
-            self.logger.setLevel(logging.INFO)
-            consolehandler = logging.StreamHandler()
-            console_format = logging.Formatter('[%(levelname)-8s][%(module)s.%(funcName)s] %(message)s')
-            consolehandler.setFormatter(console_format)
-            self.logger.addHandler(consolehandler)
-        else:
-            self.logger = logger
+
 
     def analyze_bss(self):
         self.report.append('{:-^60}'.format('analyze bss info'))
-        self.logger.info("Start analyze bss info")
+        logger.info("Start analyze bss info")
         target_function = get_function("bzero")
         if target_function:
             parms_data = dump_call_parm_value(call_address=target_function.getEntryPoint(), search_functions=['sysStart',
@@ -38,29 +41,29 @@ class VxAnalyzer(object):
                 self.report.append("bss_start_address: {}".format(hex(bss_start_address)))
                 bss_length = call_parms['parms']['parm_2']['parm_value']
                 if not bss_length:
-                    self.logger.error("Can't calculate bss length.")
+                    logger.error("Can't calculate bss length.")
                     self.report.append("Can't calculate bss length.")
                     break
                 self.report.append("bss_end_address: {}".format(hex(bss_start_address + bss_length - 1)))
                 self.report.append("bss_length: {}".format(hex(bss_length)))
-                self.logger.info("bss_end_address: {}".format(hex(bss_start_address + bss_length - 1)))
-                self.logger.info("bss_length: {}".format(hex(bss_length)))
+                logger.info("bss_end_address: {}".format(hex(bss_start_address + bss_length - 1)))
+                logger.info("bss_length: {}".format(hex(bss_length)))
                 if not is_address_in_current_program(toAddr(bss_start_address)):
                     self.report.append("bss block not in current program, adding...")
                     if create_initialized_block(block_name=".bss", start_address=toAddr(bss_start_address),
                                                 length=bss_length):
-                        self.logger.info("bss block created")
+                        logger.info("bss block created")
                     else:
-                        self.logger.info("Can't create bss block, you can create it manually")
+                        logger.info("Can't create bss block, you can create it manually")
 
         else:
-            self.logger.error("Can't find bzero function in firmware")
+            logger.error("Can't find bzero function in firmware")
 
         self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_login_accouts(self):
         hard_coded_accounts = {}
-        self.logger.info("analyze loginUserAdd function")
+        logger.info("analyze loginUserAdd function")
         self.report.append("{:-^60}".format("analyze loginUserAdd function"))
         target_function = get_function("loginUserAdd")
         if target_function:
@@ -98,10 +101,10 @@ class VxAnalyzer(object):
         else:
             self.report.append("Can't find loginUserAdd function in firmware")
 
-        self.logger.info("Found {} hard coded accounts".format(len(hard_coded_accounts)))
+        logger.info("Found {} hard coded accounts".format(len(hard_coded_accounts)))
         self.report.append("Found {} hard coded accounts".format(len(hard_coded_accounts)))
         for account in hard_coded_accounts:
-            self.logger.info("user_name: {}, pass_hash: {}, added at address: {}".format(
+            logger.info("user_name: {}, pass_hash: {}, added at address: {}".format(
                 hard_coded_accounts[account]['user_name'],
                 hard_coded_accounts[account]['pass_hash'],
                 hex(account.offset)
@@ -116,7 +119,7 @@ class VxAnalyzer(object):
 
     def analyze_service(self):
         service_status = {}
-        self.logger.info('analyze services')
+        logger.info('analyze services')
         self.report.append('{:-^60}'.format('analyze services'))
 
         for service in sorted(vxworks_service_keyword.keys()):
@@ -128,12 +131,12 @@ class VxAnalyzer(object):
                     service_status[service] = "available"
 
         for service in sorted(service_status.items(), key=lambda x: x[1], reverse=True):
-            self.logger.info('{}: {}'.format(service[0], service[1]))
+            logger.info('{}: {}'.format(service[0], service[1]))
             self.report.append('{}: {}'.format(service[0], service[1]))
         self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_symbols(self):
-        self.logger.info('analyze symbols using sysSymTbl')
+        logger.info('analyze symbols using sysSymTbl')
         self.report.append('{:-^60}'.format('analyze symbols using sysSymTbl'))
         function_manager = currentProgram.getFunctionManager()
         functions_count_before = function_manager.getFunctionCount()
@@ -150,7 +153,7 @@ class VxAnalyzer(object):
         sys_sym_addr = toAddr(getInt(sys_sym_tbl.getAddress()))
 
         if not is_address_in_current_program(sys_sym_addr):
-            self.logger.info("sys_sym_addr({:#010x}) is not in current_program".format(sys_sym_addr.getOffset()))
+            logger.info("sys_sym_addr({:#010x}) is not in current_program".format(sys_sym_addr.getOffset()))
             self.report.append("sys_sym_addr({:#010x}) is not in current_program".format(sys_sym_addr.getOffset()))
             self.report.append('{}\r\n'.format("-" * 60))
             return
@@ -168,10 +171,10 @@ class VxAnalyzer(object):
 
                     elif vx_version == u"6.x":
                         self._vx_version = 6
-                        self.logger.info(("VxHunter didn't support symbols analyze for VxWorks version 6.x"))
+                        logger.info(("VxHunter didn't support symbols analyze for VxWorks version 6.x"))
 
                 if self._vx_version == 5:
-                    self.logger.info(("Functions count: {}(Before analyze) ".format(functions_count_before)))
+                    logger.info(("Functions count: {}(Before analyze) ".format(functions_count_before)))
                     self.report.append("Functions count: {}(Before analyze) ".format(functions_count_before))
                     create_struct(sys_sym_addr, vx_5_sys_symtab)
                     hash_tbl_addr = toAddr(getInt(sys_sym_addr.add(0x04)))
@@ -180,22 +183,22 @@ class VxAnalyzer(object):
                     hash_tbl_array_addr = toAddr(getInt(hash_tbl_addr.add(0x14)))
                     hash_tbl_array_data_type = ArrayDataType(vx_5_sl_list, hash_tbl_length, vx_5_sl_list.getLength())
                     create_struct(hash_tbl_array_addr, hash_tbl_array_data_type)
-                    self.logger.info("Start fix functions")
+                    logger.info("Start fix functions")
                     for i in range(0, hash_tbl_length):
                         list_head = toAddr(getInt(hash_tbl_array_addr.add(i * 8)))
                         list_tail = toAddr(getInt(hash_tbl_array_addr.add((i * 8) + 0x04)))
                         if is_address_in_current_program(list_head) and is_address_in_current_program(list_tail):
                             fix_symbol_by_chains(list_head, list_tail, vx_version)
             except Exception as err:
-                self.logger.error(err)
+                logger.error(err)
 
             finally:
                 # Wait analyze finish.
-                self.logger.info("Waiting for pending analysis to complete...")
+                logger.info("Waiting for pending analysis to complete...")
                 analyzeChanges(currentProgram)
                 functions_count_after = function_manager.getFunctionCount()
-                self.logger.info("Functions count: {}(After analyze) ".format(functions_count_after))
-                self.logger.info("VxHunter found {} new functions".format(
+                logger.info("Functions count: {}(After analyze) ".format(functions_count_after))
+                logger.info("VxHunter found {} new functions".format(
                     functions_count_after - functions_count_before))
                 self.report.append("Functions count: {}(After analyze) ".format(functions_count_after))
                 self.report.append("VxHunter found {} new functions".format(
@@ -203,7 +206,7 @@ class VxAnalyzer(object):
                 self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_function_xref_by_symbol_get(self):
-        self.logger.info('{:-^60}'.format('analyze symFindByName function call'))
+        logger.info('{:-^60}'.format('analyze symFindByName function call'))
         self.report.append('{:-^60}'.format('analyze symFindByName function call'))
 
         # symFindByName analyze
@@ -231,7 +234,7 @@ class VxAnalyzer(object):
                         logger.debug("searched_symbol_name: {}".format(searched_symbol_name))
                         if isinstance(searched_symbol_name, unicode) is False:
                             searched_symbol_name = searched_symbol_name.value
-                        self.logger.info("Found symFindByName({}) call at {:#010x}".format(
+                        logger.info("Found symFindByName({}) call at {:#010x}".format(
                             searched_symbol_name, call_parms['call_addr'].offset))
                         self.report.append("Found symFindByName({}) call at {:#010x}".format(
                             searched_symbol_name, call_parms['call_addr'].offset))
@@ -243,7 +246,7 @@ class VxAnalyzer(object):
                             ref_from = call_parms['call_addr']
                             currentReferenceManager.addMemoryReference(ref_from, ref_to, RefType.READ,
                                                                        SourceType.USER_DEFINED, 0)
-                            self.logger.info("Add Reference for {}( {:#010x} ) function call at {:#010x} in {}( {:#010x} )".format(
+                            logger.info("Add Reference for {}( {:#010x} ) function call at {:#010x} in {}( {:#010x} )".format(
                                 to_function,
                                 ref_to.offset,
                                 call_parms['call_addr'].offset,
@@ -260,7 +263,7 @@ class VxAnalyzer(object):
                             ))
 
                         else:
-                            self.logger.error("Can't find {} symbol in firmware".format(searched_symbol_name))
+                            logger.error("Can't find {} symbol in firmware".format(searched_symbol_name))
 
                         logger.debug("{}({}) at {:#010x} in {}({:#010x})".format(target_function.name, searched_symbol_name,
                                                                                  call_parms['call_addr'].offset,
@@ -268,15 +271,26 @@ class VxAnalyzer(object):
                                                                                  call_parms['refrence_function_addr'].offset
                                                                                  ))
                 except Exception as err:
-                    self.logger.error(err)
+                    logger.error(err)
 
         else:
-            self.logger.error("Can't find {} function in firmware".format(target_function))
+            logger.error("Can't find {} function in firmware".format(target_function))
 
         self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_netpool(self):
-        self.logger.info('analyze netpool')
+        if not self._vx_version:
+            vx_version = askChoice("Choice", "Please choose VxWorks main Version ", ["5.x", "6.x"], "5.x")
+
+        if vx_version == u"5.x":
+            self._vx_version = 5
+
+        elif vx_version == u"6.x":
+            self._vx_version = 6
+            logger.error("VxHunter didn't support netpool analyze for VxWorks version 6.x")
+            self.report.append("VxHunter didn't support netpool analyze for VxWorks version 6.x")
+            return
+        logger.info('analyze netpool')
         self.report.append('{:-^60}'.format('analyze netpool'))
         pools = ["_pNetDpool", "_pNetSysPool"]
         for pool in pools:
@@ -285,27 +299,16 @@ class VxAnalyzer(object):
             net_dpool_addr = toAddr(getInt(net_dpool.getAddress()))
 
             if not is_address_in_current_program(net_dpool_addr):
-                self.logger.error("{}({:#010x}) is not in current_program".format(pool, net_dpool_addr.getOffset()))
+                logger.error("{}({:#010x}) is not in current_program".format(pool, net_dpool_addr.getOffset()))
                 self.report.append("{}({:#010x}) is not in current_program".format(pool, net_dpool_addr.getOffset()))
 
             elif net_dpool_addr.getOffset() == 0:
                 pass
 
-            self.logger.info("Found {} at {:#010x}".format(pool, net_dpool_addr.getOffset()))
+            logger.info("Found {} at {:#010x}".format(pool, net_dpool_addr.getOffset()))
             self.report.append("Found {} at {:#010x}".format(pool, net_dpool_addr.getOffset()))
 
             try:
-                if not self._vx_version:
-                    vx_version = askChoice("Choice", "Please choose VxWorks main Version ", ["5.x", "6.x"], "5.x")
-
-                    if vx_version == u"5.x":
-                        self._vx_version = 5
-
-                    elif vx_version == u"6.x":
-                        self._vx_version = 6
-                        self.logger.error("VxHunter didn't support netpool analyze for VxWorks version 6.x")
-                        self.report.append("VxHunter didn't support netpool analyze for VxWorks version 6.x")
-
                 if self._vx_version == 5:
                     net_pool_info = fix_netpool(net_dpool_addr, self._vx_version)
                     pool_addr = net_pool_info["pool_addr"]
@@ -333,43 +336,44 @@ class VxAnalyzer(object):
                         cl_pool_count += 1
 
             except Exception as err:
-                self.logger.error(err)
+                logger.error(err)
 
         self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_active_task(self):
-        self.logger.info('analyze active task')
+        logger.info('analyze active task')
         self.report.append('{:-^60}'.format('analyze task'))
         active_qhead = get_symbol("activeQHead")
-        active_qhead_addr = active_qhead.getAddress()
-        create_struct(active_qhead_addr, vx_5_q_head)
-        active_task_head_ptr = active_qhead_addr.add(0x04)
-        active_task_head = toAddr(getInt(active_task_head_ptr))
-        tcb_addr = active_task_head.add(-0x20)
-        first_tcb_addr = tcb_addr
+        if active_qhead:
+            active_qhead_addr = active_qhead.getAddress()
+            create_struct(active_qhead_addr, vx_5_q_head)
+            active_task_head_ptr = active_qhead_addr.add(0x04)
+            active_task_head = toAddr(getInt(active_task_head_ptr))
+            tcb_addr = active_task_head.add(-0x20)
+            first_tcb_addr = tcb_addr
 
-        while True:
-            # TODO: Print task info pretty
-            tcb_info = fix_tcb(tcb_addr, self._vx_version)
-            task_name = tcb_info["task_name"]
-            task_entry_addr = tcb_info["task_entry_addr"]
-            task_entry_name = tcb_info["task_entry_name"]
-            task_stack_base = tcb_info["task_stack_base"]
-            task_stack_limit = tcb_info["task_stack_limit"]
-            task_stack_limit_end = tcb_info["task_stack_limit_end"]
-            task_info_data = "  Task name: {}  Entry: {}({:#010x})  tid: {:#010x}  " \
-                             "stack base: {:#010x}   stack limit {:#010x}   stack end {:#010x}".format(
-                task_name, task_entry_name, task_entry_addr, tcb_addr.getOffset(), task_stack_base,
-                task_stack_limit, task_stack_limit_end
-            )
-            self.report.append(task_info_data)
-            next_active_task_ptr = tcb_addr.add(0x24)
-            next_active_task = toAddr(getInt(next_active_task_ptr))
-            if next_active_task.getOffset() == 0:
-                break
-            tcb_addr = next_active_task.add(-0x20)
-            if tcb_addr == first_tcb_addr or is_address_in_current_program(tcb_addr) is False:
-                break
+            while True:
+                # TODO: Print task info pretty
+                tcb_info = fix_tcb(tcb_addr, self._vx_version)
+                task_name = tcb_info["task_name"]
+                task_entry_addr = tcb_info["task_entry_addr"]
+                task_entry_name = tcb_info["task_entry_name"]
+                task_stack_base = tcb_info["task_stack_base"]
+                task_stack_limit = tcb_info["task_stack_limit"]
+                task_stack_limit_end = tcb_info["task_stack_limit_end"]
+                task_info_data = "  Task name: {}  Entry: {}({:#010x})  tid: {:#010x}  " \
+                                "stack base: {:#010x}   stack limit {:#010x}   stack end {:#010x}".format(
+                    task_name, task_entry_name, task_entry_addr, tcb_addr.getOffset(), task_stack_base,
+                    task_stack_limit, task_stack_limit_end
+                )
+                self.report.append(task_info_data)
+                next_active_task_ptr = tcb_addr.add(0x24)
+                next_active_task = toAddr(getInt(next_active_task_ptr))
+                if next_active_task.getOffset() == 0:
+                    break
+                tcb_addr = next_active_task.add(-0x20)
+                if tcb_addr == first_tcb_addr or is_address_in_current_program(tcb_addr) is False:
+                    break
 
         self.report.append('{}\r\n'.format("-" * 60))
 


### PR DESCRIPTION
Hello! I am back with another PR. I hope that it meets you well!

This PR fixes an exception in `analyze_active_task` in VxAnalyzer. When `active_qhead` is `None`, the function causes an exception. I avoid this by nesting all of that code in an `if active_qhead` block.

This PR also proposes a change in logging, and if you enjoy the change, I would gladly propagate it throughout the rest of the project. Loggers, in my opinion, should not be a part of the object. Instead, just instantiate a common logger in a script, and have a class use that. Mere suggestion -- if you prefer the way you have it, I will gladly revert.

Finally, I noticed that Netpool analysis could fail faster: since it is unsupported in VxWorks 6.x, we should ask for the VxWorks version immediately, and return immediately supposing that 6.x is chosen.