### PR TITLE
Bug Fix for VxAnalyzer, Fail Faster in Netpool Analysis

### DIFF
--- a/firmware_tools/ghidra/vxhunter_analysis.py
+++ b/firmware_tools/ghidra/vxhunter_analysis.py
@@ -1,9 +1,11 @@
+import json
+
+from ghidra.program.model.symbol import RefType, SourceType
+
 from vxhunter_core import *
+from vxhunter_utility.common import create_initialized_block
 from vxhunter_utility.function_analyzer import *
 from vxhunter_utility.symbol import *
-from vxhunter_utility.common import create_initialized_block
-from ghidra.program.model.symbol import RefType, SourceType
-import json
 
 
 class VxAnalyzer(object):
@@ -276,6 +278,18 @@ class VxAnalyzer(object):
         self.report.append('{}\r\n'.format("-" * 60))
 
     def analyze_netpool(self):
+        if not self._vx_version:
+            vx_version = askChoice("Choice", "Please choose VxWorks main Version ", ["5.x", "6.x"], "5.x")
+
+            if vx_version == u"5.x":
+                self._vx_version = 5
+
+            elif vx_version == u"6.x":
+                self._vx_version = 6
+                self.logger.error("VxHunter didn't support netpool analyze for VxWorks version 6.x")
+                self.report.append("VxHunter didn't support netpool analyze for VxWorks version 6.x")
+                return
+
         self.logger.info('analyze netpool')
         self.report.append('{:-^60}'.format('analyze netpool'))
         pools = ["_pNetDpool", "_pNetSysPool"]
@@ -295,17 +309,6 @@ class VxAnalyzer(object):
             self.report.append("Found {} at {:#010x}".format(pool, net_dpool_addr.getOffset()))
 
             try:
-                if not self._vx_version:
-                    vx_version = askChoice("Choice", "Please choose VxWorks main Version ", ["5.x", "6.x"], "5.x")
-
-                    if vx_version == u"5.x":
-                        self._vx_version = 5
-
-                    elif vx_version == u"6.x":
-                        self._vx_version = 6
-                        self.logger.error("VxHunter didn't support netpool analyze for VxWorks version 6.x")
-                        self.report.append("VxHunter didn't support netpool analyze for VxWorks version 6.x")
-
                 if self._vx_version == 5:
                     net_pool_info = fix_netpool(net_dpool_addr, self._vx_version)
                     pool_addr = net_pool_info["pool_addr"]
@@ -341,35 +344,36 @@ class VxAnalyzer(object):
         self.logger.info('analyze active task')
         self.report.append('{:-^60}'.format('analyze task'))
         active_qhead = get_symbol("activeQHead")
-        active_qhead_addr = active_qhead.getAddress()
-        create_struct(active_qhead_addr, vx_5_q_head)
-        active_task_head_ptr = active_qhead_addr.add(0x04)
-        active_task_head = toAddr(getInt(active_task_head_ptr))
-        tcb_addr = active_task_head.add(-0x20)
-        first_tcb_addr = tcb_addr
+        if active_qhead:
+            active_qhead_addr = active_qhead.getAddress()
+            create_struct(active_qhead_addr, vx_5_q_head)
+            active_task_head_ptr = active_qhead_addr.add(0x04)
+            active_task_head = toAddr(getInt(active_task_head_ptr))
+            tcb_addr = active_task_head.add(-0x20)
+            first_tcb_addr = tcb_addr
 
-        while True:
-            # TODO: Print task info pretty
-            tcb_info = fix_tcb(tcb_addr, self._vx_version)
-            task_name = tcb_info["task_name"]
-            task_entry_addr = tcb_info["task_entry_addr"]
-            task_entry_name = tcb_info["task_entry_name"]
-            task_stack_base = tcb_info["task_stack_base"]
-            task_stack_limit = tcb_info["task_stack_limit"]
-            task_stack_limit_end = tcb_info["task_stack_limit_end"]
-            task_info_data = "  Task name: {}  Entry: {}({:#010x})  tid: {:#010x}  " \
-                             "stack base: {:#010x}   stack limit {:#010x}   stack end {:#010x}".format(
-                task_name, task_entry_name, task_entry_addr, tcb_addr.getOffset(), task_stack_base,
-                task_stack_limit, task_stack_limit_end
-            )
-            self.report.append(task_info_data)
-            next_active_task_ptr = tcb_addr.add(0x24)
-            next_active_task = toAddr(getInt(next_active_task_ptr))
-            if next_active_task.getOffset() == 0:
-                break
-            tcb_addr = next_active_task.add(-0x20)
-            if tcb_addr == first_tcb_addr or is_address_in_current_program(tcb_addr) is False:
-                break
+            while True:
+                # TODO: Print task info pretty
+                tcb_info = fix_tcb(tcb_addr, self._vx_version)
+                task_name = tcb_info["task_name"]
+                task_entry_addr = tcb_info["task_entry_addr"]
+                task_entry_name = tcb_info["task_entry_name"]
+                task_stack_base = tcb_info["task_stack_base"]
+                task_stack_limit = tcb_info["task_stack_limit"]
+                task_stack_limit_end = tcb_info["task_stack_limit_end"]
+                task_info_data = "  Task name: {}  Entry: {}({:#010x})  tid: {:#010x}  " \
+                                "stack base: {:#010x}   stack limit {:#010x}   stack end {:#010x}".format(
+                    task_name, task_entry_name, task_entry_addr, tcb_addr.getOffset(), task_stack_base,
+                    task_stack_limit, task_stack_limit_end
+                )
+                self.report.append(task_info_data)
+                next_active_task_ptr = tcb_addr.add(0x24)
+                next_active_task = toAddr(getInt(next_active_task_ptr))
+                if next_active_task.getOffset() == 0:
+                    break
+                tcb_addr = next_active_task.add(-0x20)
+                if tcb_addr == first_tcb_addr or is_address_in_current_program(tcb_addr) is False:
+                    break
 
         self.report.append('{}\r\n'.format("-" * 60))
 


### PR DESCRIPTION
Hello! Here is a PR that doesn't include any changes to logging whatsoever. I've packed it into one commit to make your life easier. I hope you enjoy!

This PR fixes an exception in analyze_active_task in VxAnalyzer. When active_qhead is None, the function causes an exception. I avoid this by nesting all of that code in an if active_qhead block.

Also, I noticed that Netpool analysis could fail faster: since it is unsupported in VxWorks 6.x, we should ask for the VxWorks version immediately, and return immediately supposing that 6.x is chosen.